### PR TITLE
provision: support for cleaning zypper repos

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -48,6 +48,10 @@ else
   hosts = Vagrant::Hosts.new(config[CONFIGURATION]['nodes'])
 end
 
+def provisioned?(vm_name='default', provider='libvirt')
+  File.exist?(".vagrant/machines/#{vm_name}/#{provider}/action_provision")
+end
+
 def provisioning(hosts, node, config, name)
       # Update /etc/hosts on each node
       hosts.update(node)
@@ -60,6 +64,9 @@ def provisioning(hosts, node, config, name)
 
       # Add missing repos
       repos = Vagrant::Repos.new(node, config[BOX][INSTALLATION]['repos'])
+      if ENV.has_key?("CLEAN_ZYPPER_REPOS") or !provisioned?(name)
+        repos.clean
+      end
       repos.add
 
       # Copy custom files 

--- a/lib/provisions.rb
+++ b/lib/provisions.rb
@@ -21,6 +21,10 @@ module Vagrant
       end
     end
 
+    def clean
+      @node.vm.provision 'shell', inline: "sudo rm -f /etc/zypp/repos.d/*"
+    end
+
     # Runs all the commands in a single shell
     def add
       @node.vm.provision 'shell', inline: @cmds.join('; ') 


### PR DESCRIPTION
Add support to clean the zypper repos before adding the repos present in conf.yml.

Useful when base boxes already have zypper repos install, or when one wants to update the list of repos in config.yml.

The cleaning will be done when the VMs are first provisioned. To force the cleaning after the first provision, use the environment variable `CLEAN_ZYPPER_REPOS=ON`.

Signed-off-by: Ricardo Dias rdias@suse.com
