### PR TITLE
Fix permission issue through the use of the files upload feature

### DIFF
--- a/lib/provisions.rb
+++ b/lib/provisions.rb
@@ -163,7 +163,7 @@ module Vagrant
     #
     #   tar_file - path to tar file
     def untar(tar_file)
-      cmd = "tar -C / -xf #{tar_file}"
+      cmd = "tar --no-overwrite-dir -C / -xf #{tar_file}"
       @node.vm.provision 'shell', inline: cmd
     end
   end


### PR DESCRIPTION
which also resulted in problems SSH'ing into the machines because `/root` or `/home/vagrant/` may have the wrong permissions if files have been tranfered to that directories.
